### PR TITLE
Fix admin panel issues that Docker complained about

### DIFF
--- a/solution/backend/resources/admin/internal_resources.py
+++ b/solution/backend/resources/admin/internal_resources.py
@@ -25,7 +25,12 @@ class InternalLinkForm(AbstractInternalResourceForm):
 class InternalLinkAdmin(AbstractInternalResourceAdmin):
     admin_priority = 20
     form = InternalLinkForm
-    list_display = ["date", "document_id", "title", "category__name", "updated_at", "approved"]
+    
+    def category_name(self, obj):
+        return obj.category.name if obj.category else "-"
+    category_name.short_description = "Category"
+    
+    list_display = ["date", "document_id", "title", "category_name", "updated_at", "approved"]
     list_display_links = ["date", "document_id", "title", "updated_at"]
     search_fields = ["date", "document_id", "title", "summary"]
 
@@ -68,7 +73,12 @@ class InternalFileForm(AbstractInternalResourceForm):
 class InternalFileAdmin(AbstractInternalResourceAdmin):
     admin_priority = 21
     form = InternalFileForm
-    list_display = ["date", "document_id", "title", "category__name", "updated_at", "approved"]
+    
+    def category_name(self, obj):
+        return obj.category.name if obj.category else "-"
+    category_name.short_description = "Category"
+    
+    list_display = ["date", "document_id", "title", "category_name", "updated_at", "approved"]
     list_display_links = ["date", "document_id", "title", "updated_at"]
     search_fields = ["date", "document_id", "title", "summary"]
     readonly_fields = ["download_file", "file_name", "file_type"]

--- a/solution/backend/resources/admin/public_resources.py
+++ b/solution/backend/resources/admin/public_resources.py
@@ -30,7 +30,13 @@ class PublicLinkForm(AbstractPublicResourceForm):
 class PublicLinkAdmin(AbstractPublicResourceAdmin):
     admin_priority = 10
     form = PublicLinkForm
-    list_display = ["date", "document_id", "title", "category__name", "updated_at", "approved"]
+    
+    def category_name(self, obj):
+        return obj.category.name if obj.category else "-"
+    category_name.short_description = "Category"
+    
+    
+    list_display = ["date", "document_id", "title", "category_name", "updated_at", "approved"]
     list_display_links = ["date", "document_id", "title", "updated_at"]
     search_fields = ["date", "document_id", "title", "url"]
 


### PR DESCRIPTION
Couldn't build locally because I kept getting the following error message:

```
<class 'resources.admin.internal_resources.InternalFileAdmin'>: (admin.E108) The value of 'list_display[3]' refers to 'category__name', which is not a callable, an attribute of 'InternalFileAdmin', or an attribute or method on 'resources.InternalFile'.
<class 'resources.admin.internal_resources.InternalLinkAdmin'>: (admin.E108) The value of 'list_display[3]' refers to 'category__name', which is not a callable, an attribute of 'InternalLinkAdmin', or an attribute or method on 'resources.InternalLink'.
<class 'resources.admin.public_resources.PublicLinkAdmin'>: (admin.E108) The value of 'list_display[3]' refers to 'category__name', which is not a callable, an attribute of 'PublicLinkAdmin', or an attribute or method on 'resources.PublicLink'.
```

I asked a LLM to help me fix it. 😅 Creating a PR in case this is useful for making it build locally for others as well.