### PR TITLE
Updates SCSS files with new colors 

### DIFF
--- a/solution/ui/regulations/css/scss/_application_settings.scss
+++ b/solution/ui/regulations/css/scss/_application_settings.scss
@@ -110,25 +110,25 @@ $mark_highlight: #fce5af;
 */
 
 // Base Colors - Policy Connector
-$mid_red: #DC3933;
-$light_red: #FFEAEA;
-$mid_beige: #D4B086;
-$light_beige: #F2E4D4;
+$mid_red: #DC3933; /*top nav and popup border*/
+$light_red: #FFEAEA;  /*doc slug background for policy repository*/
+$mid_beige: #D4B086; /*reg border*/
+$light_beige: #F2E4D4; /*reg lug background & jump button*/
 
-$darker_blue: #1A4480;
-$darkest_purple: #222660;
-$dark_purple: #3B43BC;
-$light_purple: #B7BAE5;
-$dark_blue: #07648D;
+$darker_blue: #1A4480; /*side link and button background*/
+$darkest_purple: #222660; /*button hover and policy repository slug*/
+$dark_purple: #3B43BC; /*visited link*/
+$light_purple: #B7BAE5; /*reverse default background and reverse link text*/
+$dark_blue: #07648D; /*main text link*/ 
 
-$darkest_gray: #1B1B1B;
-$darker_gray: #5B616B;
-$mid_gray3: #767676;
-$mid_gray2: #A3A3A3; 
-$light_gray: #DCDCDC;
-$lightest_gray: #F3F3F3;
+$darkest_gray: #1B1B1B; /*base text*/
+$darker_gray: #5B616B; /*public and internal slug*/
+$mid_gray: #767676; /*disabled*/
+$mid_gray_warm: #A3A3A3; /*?*/
+$light_gray: #DCDCDC; /*side nav top background and disabled button background*/
+$lightest_gray: #F3F3F3; /*side nav main background*/
 
-$white: #fff;
+$white: #fff; /*default background and reverse button background*/
 
 $green: #2a7a3b;
 
@@ -158,7 +158,7 @@ $reverse_link_hover: $white;
 $secondary_reverse_link_color: $white;
 $secondary_reverse_link_hover: $light_blue;
 
-$visited_link_color: $magenta;
+$visited_link_color: $dark_purple; /*updated*/
 
 $secondary_toc_link_color: $light_blue_2;
 
@@ -176,17 +176,17 @@ $reverse_background_darker: $darkest_blue;
 $reverse_background_lighter: $mid_dark_blue;
 $table_header_background_color: $lightest_gray;
 
-$hero_background_color: $teal;
-$hero_link_color: $white;
-$hero_link_hover: $light_blue;
+$hero_background_color: $mid_red; 
+$hero_link_color: $white; 
+$hero_link_hover: $light_red;
 
-$contact_link_color: $lightest_blue;
+$contact_link_color: $light_red;
 
-$jump_to_submit_disabled: $mid_gray_3;
-$jump_to_submit_active: $mid_blue;
-$jump_to_submit_active_focus: $dark_blue;
+$jump_to_submit_disabled: $light_gray; 
+$jump_to_submit_active: $light_beige;
+$jump_to_submit_active_focus: $mid_beige;
 
-$policy_subject_selected_chip_background: $dark_blue;
+$policy_subject_selected_chip_background: $dark_blue; 
 
 $choice-checked-background-color: $mid_blue;
 $choice-checked-border-color: $mid_blue;

--- a/solution/ui/regulations/css/scss/_application_settings.scss
+++ b/solution/ui/regulations/css/scss/_application_settings.scss
@@ -173,6 +173,7 @@ $placeholder_color: $mid_gray;
 
 $main_background_color: $white;
 $secondary_background_color: $lightest_gray;
+$secondary_background_active: $light_gray;
 $teritary_background_color: $light_red;
 $reverse_background_color: $dark_blue;
 $reverse_background_darker: $darker_blue;
@@ -198,7 +199,7 @@ $choice-checked-border-color: $dark_blue;
 
 $border_color: $light_gray;
 $secondary_border_color: $light_red;
-$tertiary_border_color: $darker_gray;
+$tertiary_border_color: $darker_gray; /*TO DO: swap this value with secondary everywhere*/
 $hover_border_color: $mid_red;
 $table_border_color: $light_gray;
 $formula_left_border: $light_red;

--- a/solution/ui/regulations/css/scss/_application_settings.scss
+++ b/solution/ui/regulations/css/scss/_application_settings.scss
@@ -199,7 +199,7 @@ $choice-checked-border-color: $dark_blue;
 
 $border_color: $light_gray;
 $secondary_border_color: $light_red;
-$tertiary_border_color: $darker_gray; /*TO DO: swap this value with secondary everywhere*/
+$tertiary_border_color: $darker_gray; /*TO DO: swap this value with secondary everywher*/
 $hover_border_color: $mid_red;
 $table_border_color: $light_gray;
 $formula_left_border: $light_red;

--- a/solution/ui/regulations/css/scss/_application_settings.scss
+++ b/solution/ui/regulations/css/scss/_application_settings.scss
@@ -194,10 +194,10 @@ $choice-checked-border-color: $mid_blue;
 // Borders
 
 $border_color: $light_gray;
-$secondary_border_color: $mid_blue;
-$hover_border_color: $light_blue;
+$secondary_border_color: $light_red;
+$hover_border_color: $mid_red;
 $table_border_color: $light_gray;
-$formula_left_border: $light_blue;
+$formula_left_border: $light_red;
 
 // Text
 

--- a/solution/ui/regulations/css/scss/_application_settings.scss
+++ b/solution/ui/regulations/css/scss/_application_settings.scss
@@ -75,6 +75,7 @@ ol {
 // Colors
 //--------------------------
 
+/*
 // Base Colors
 $teal: #026666;
 $teal_blue: #245c68;
@@ -106,6 +107,31 @@ $green: #2a7a3b;
 $title_color: #000;
 $section_highlight_color: #eefafe;
 $mark_highlight: #fce5af;
+*/
+
+// Base Colors - Policy Connector
+$mid_red: #DC3933;
+$light_red: #FFEAEA;
+$mid_beige: #D4B086;
+$light_beige: #F2E4D4;
+
+$darker_blue: #1A4480;
+$darkest_purple: #222660;
+$dark_purple: #3B43BC;
+$light_purple: #B7BAE5;
+$dark_blue: #07648D;
+
+$darkest_gray: #1B1B1B;
+$darker_gray: #5B616B;
+$mid_gray3: #767676;
+$mid_gray2: #A3A3A3; 
+$light_gray: #DCDCDC;
+$lightest_gray: #F3F3F3;
+
+$white: #fff;
+
+$green: #2a7a3b;
+
 
 //// Usage ////
 //// Call This Section in Your CSS, Not the Color Names ////

--- a/solution/ui/regulations/css/scss/_application_settings.scss
+++ b/solution/ui/regulations/css/scss/_application_settings.scss
@@ -132,8 +132,8 @@ $white: #fff; /*default background and reverse button background*/
 
 $green: #2a7a3b;
 $title_color: #1B1B1B;
-$section_highlight_color: #eefafe;
-$mark_highlight: #fce5af;
+$section_highlight_color: #F2E4D4;
+$mark_highlight: #F2E4D4;
 
 
 //// Usage ////
@@ -142,7 +142,7 @@ $mark_highlight: #fce5af;
 // Colors
 
 $primary_color: $dark_blue;
-$secondary_color: $teal;
+$secondary_color: $light_beige;
 
 // Links
 

--- a/solution/ui/regulations/css/scss/_application_settings.scss
+++ b/solution/ui/regulations/css/scss/_application_settings.scss
@@ -123,7 +123,7 @@ $dark_blue: #07648D; /*main text link*/
 
 $darkest_gray: #1B1B1B; /*base text*/
 $darker_gray: #5B616B; /*public and internal slug*/
-$mid_gray: #767676; /*disabled*/
+$mid_gray: #767676; /*disabled and placeholder*/
 $mid_gray_warm: #A3A3A3; /*?*/
 $light_gray: #DCDCDC; /*side nav top background and disabled button background*/
 $lightest_gray: #F3F3F3; /*side nav main background*/
@@ -131,6 +131,9 @@ $lightest_gray: #F3F3F3; /*side nav main background*/
 $white: #fff; /*default background and reverse button background*/
 
 $green: #2a7a3b;
+$title_color: #1B1B1B;
+$section_highlight_color: #eefafe;
+$mark_highlight: #fce5af;
 
 
 //// Usage ////
@@ -143,28 +146,28 @@ $secondary_color: $teal;
 
 // Links
 
-$primary_link_color: $mid_blue;
-$primary_link_hover: $dark_blue;
+$primary_link_color: $$dark_blue;
+$primary_link_hover: $dark_purple;
 
-$secondary_link_color: $teal;
-$secondary_link_hover: $mid_blue;
+$secondary_link_color: $darker_blue;
+$secondary_link_hover: $darkest_purple;
 
 $teritary_link_color: $darker_blue;
 $teritary_link_hover: $darkest_purple;
 
-$reverse_link_color: $light_blue;
+$reverse_link_color: $light_purple;
 $reverse_link_hover: $white;
 
 $secondary_reverse_link_color: $white;
-$secondary_reverse_link_hover: $light_blue;
+$secondary_reverse_link_hover: $light_purple;
 
-$visited_link_color: $dark_purple; /*updated*/
+$visited_link_color: $dark_purple; 
 
-$secondary_toc_link_color: $light_blue_2;
+$secondary_toc_link_color: $darker_blue;
 
 // Forms
 
-$placeholder_color: $mid_gray_2;
+$placeholder_color: $mid_gray;
 
 // Backgrounds
 
@@ -201,10 +204,11 @@ $formula_left_border: $light_red;
 
 // Text
 
-$primary_text_color: $dark_gray;
-$secondary_text_color: $mid_gray;
+$primary_text_color: $darkest_gray;
+$secondary_text_color: $darker_gray;
 $reverse_text_color: $white;
-$policy_subject_selected_chip_text: #fff;
+
+$policy_subject_selected_chip_text: $white;
 
 // Indicators
 

--- a/solution/ui/regulations/css/scss/_application_settings.scss
+++ b/solution/ui/regulations/css/scss/_application_settings.scss
@@ -113,7 +113,7 @@ $mark_highlight: #fce5af;
 $mid_red: #DC3933; /*top nav and popup border*/
 $light_red: #FFEAEA;  /*doc slug background for policy repository*/
 $mid_beige: #D4B086; /*reg border*/
-$light_beige: #F2E4D4; /*reg lug background & jump button*/
+$light_beige: #F2E4D4; /*reg slug background & jump button*/
 
 $darker_blue: #1A4480; /*side link and button background*/
 $darkest_purple: #222660; /*button hover and policy repository slug*/
@@ -229,14 +229,14 @@ $tertiary_indicator_background: $white;
 
 // Buttons
 
-$main_button_background: $light_blue;
-$main_button_color: $dark_blue;
-$main_button_hover_background: $white;
+$main_button_background: $darker_blue;
+$main_button_color: $white;
+$main_button_hover_background: $darkest_purple;
 
 $copy_button_success: $green;
 
 $policy_subject_close_background: $light_gray;
-$policy_subject_close_background_hover: $mid_gray_3;
+$policy_subject_close_background_hover: $mid_gray;
 
 //--------------------------
 // Fonts

--- a/solution/ui/regulations/css/scss/_application_settings.scss
+++ b/solution/ui/regulations/css/scss/_application_settings.scss
@@ -175,9 +175,9 @@ $main_background_color: $white;
 $secondary_background_color: $lightest_gray;
 $teritary_background_color: $light_red;
 $reverse_background_color: $dark_blue;
-$reverse_background_darker: $darkest_blue;
-$reverse_background_lighter: $mid_dark_blue;
-$table_header_background_color: $lightest_gray;
+$reverse_background_darker: $darker_blue;
+$reverse_background_lighter: $dark_blue;
+$table_header_background_color: $light_gray;
 
 $hero_background_color: $mid_red; 
 $hero_link_color: $white; 
@@ -198,6 +198,7 @@ $choice-checked-border-color: $dark_blue;
 
 $border_color: $light_gray;
 $secondary_border_color: $light_red;
+$tertiary_border_color: $darker_gray;
 $hover_border_color: $mid_red;
 $table_border_color: $light_gray;
 $formula_left_border: $light_red;
@@ -233,7 +234,7 @@ $tertiary_indicator_background: $white;
 $main_button_background: $darker_blue;
 $main_button_color: $white;
 $main_button_hover_background: $darkest_purple;
-
+$main_button_disabled: $light_gray; 
 $copy_button_success: $green;
 
 $policy_subject_close_background: $light_gray;

--- a/solution/ui/regulations/css/scss/_application_settings.scss
+++ b/solution/ui/regulations/css/scss/_application_settings.scss
@@ -149,8 +149,8 @@ $primary_link_hover: $dark_blue;
 $secondary_link_color: $teal;
 $secondary_link_hover: $mid_blue;
 
-$teritary_link_color: $dark_blue;
-$teritary_link_hover: $mid_blue;
+$teritary_link_color: $darker_blue;
+$teritary_link_hover: $darkest_purple;
 
 $reverse_link_color: $light_blue;
 $reverse_link_hover: $white;
@@ -170,7 +170,7 @@ $placeholder_color: $mid_gray_2;
 
 $main_background_color: $white;
 $secondary_background_color: $lightest_gray;
-$teritary_background_color: $lightest_blue;
+$teritary_background_color: $light_red;
 $reverse_background_color: $dark_blue;
 $reverse_background_darker: $darkest_blue;
 $reverse_background_lighter: $mid_dark_blue;

--- a/solution/ui/regulations/css/scss/_application_settings.scss
+++ b/solution/ui/regulations/css/scss/_application_settings.scss
@@ -146,7 +146,7 @@ $secondary_color: $teal;
 
 // Links
 
-$primary_link_color: $$dark_blue;
+$primary_link_color: $dark_blue;
 $primary_link_hover: $dark_purple;
 
 $secondary_link_color: $darker_blue;
@@ -191,8 +191,8 @@ $jump_to_submit_active_focus: $mid_beige;
 
 $policy_subject_selected_chip_background: $dark_blue; 
 
-$choice-checked-background-color: $mid_blue;
-$choice-checked-border-color: $mid_blue;
+$choice-checked-background-color: $dark_blue;
+$choice-checked-border-color: $dark_blue;
 
 // Borders
 
@@ -206,13 +206,14 @@ $formula_left_border: $light_red;
 
 $primary_text_color: $darkest_gray;
 $secondary_text_color: $darker_gray;
+$tertiary_text_color: $mid_gray;
 $reverse_text_color: $white;
 
 $policy_subject_selected_chip_text: $white;
 
 // Indicators
 
-$primary_indicator_background: $teal;
+$primary_indicator_background: $mid_red;
 $primary_indicator_text: $white;
 
 $secondary_indicator_background: $light_gray;
@@ -606,11 +607,10 @@ select {
 // Other Common Settings
 // -------------------------
 
-// Blue chips used for Resources selections and Policy Doc subjects
+// Chips used for Resources selections and Policy Doc subjects
 @mixin common-chip-colors {
-    background: $lightest_blue;
-    color: $mid_blue;
-    border: 1px solid #c0eaf8;
+    background: $darkest_blue;
+    color: $white;
 }
 
 @mixin common-chip-styles {

--- a/solution/ui/regulations/css/scss/_eregs_design_system.scss
+++ b/solution/ui/regulations/css/scss/_eregs_design_system.scss
@@ -36,8 +36,8 @@ $eds-width-header-links: 1240px;
     --text-input__border-width: 1px;
     --text-input__border-width--disabled: 1px;
 
-    // Color overrides
-    --color-focus-dark: #005fcc;
+    // Color overrides - TO DO 
+    --color-focus-dark: #222660; 
 }
 
 @mixin eds-gutters {

--- a/solution/ui/regulations/css/scss/_layout.scss
+++ b/solution/ui/regulations/css/scss/_layout.scss
@@ -77,7 +77,7 @@ main {
 
 aside {
     &.left-sidebar {
-        background: $reverse_background_color;
+        background: $secondary_background_color;
         padding: 0;
         flex-shrink: 0;
     }
@@ -159,9 +159,9 @@ footer {
     bottom: 0;
     right: 0;
     padding: 1rem 3rem 1rem 1rem;
-    background-color: $lighter_gray;
-    border-top: 1px solid $light_gray;
-    border-left: 1px solid $light_gray;
+    background-color: $secondary_background_color;
+    border-top: 1px solid $border_color;
+    border-left: 1px solid $border_color;
     border-top-left-radius: 10px;
     box-shadow: -3px 3px 10px 0px rgba(0, 0, 0, 0.08);
     -webkit-box-shadow: -3px 3px 10px 0px rgba(0, 0, 0, 0.08);
@@ -176,15 +176,15 @@ footer {
         width: 10px;
         height: 10px;
         border-radius: 50%;
-        background-color: $teal;
+        background-color: $hero_background_color;
         margin-right: 0.5rem;
 
         &--success {
-            background-color: $green;
+            background-color: $copy_button_success;
         }
 
         &--error {
-            background-color: $mid_gray_3;
+            background-color: $secondary_background_color;
         }
     }
 

--- a/solution/ui/regulations/css/scss/partials/_buttons_and_tooltip.scss
+++ b/solution/ui/regulations/css/scss/partials/_buttons_and_tooltip.scss
@@ -6,7 +6,7 @@
 
 @mixin sidebar-hr-styles {
     height: 1px;
-    background: $light_gray;
+    background: $secondary_background_color;
     border: none;
     margin: 15px 0;
 }
@@ -41,15 +41,14 @@
 
 .default-btn {
     display: flex;
-    color: white;
-    background: $mid-blue;
-    border-color: rgba(0, 0, 0, 0);
+    color: $white;
+    background: $main_button_background;
 
     &:hover,
     &:focus,
     &:focus:visited {
-        background: $mid-dark-blue;
-        background-color: $mid-dark-blue;
+        background: $main_button_hover_background;
+        background-color: $main_button_hover_background;
     }
 }
 
@@ -80,22 +79,23 @@
 
 .trigger-btn,
 .link-btn {
-    color: $mid_blue;
+    color: $main_button_background;
     cursor: pointer;
     line-height: 1.2;
 
     &:focus {
-        color: $dark_blue;
+        color: $main_button_hover_background;
     }
 
     &:hover {
-        color: $dark_blue;
+        color: $main_button_hover_background;
     }
 }
 
 @mixin default-tooltip {
     cursor: default;
-    background: $lightest_blue;
+    background: $tertiary_indicator_background;
+    border: 1px solid $border_color;
     box-shadow: 0px 0px 20px 0px #00000040;
 }
 
@@ -107,7 +107,7 @@
     box-sizing: content-box;
 
     p {
-        color: $dark_gray;
+        color: $secondary_text_color;
         padding: 0;
     }
 
@@ -139,14 +139,14 @@
             width: 40px;
 
             path {
-                stroke: $mid_blue;
-                fill: $mid_blue;
+                stroke: $primary_color;
+                fill: $primary_color;
             }
 
             &:hover {
                 path {
-                    stroke: $dark_blue;
-                    fill: $dark_blue;
+                    stroke: $darkest_purple;
+                    fill: $darkest_purple;
                 }
             }
         }
@@ -165,7 +165,7 @@
     &::after {
         border-right: solid 5px transparent;
         border-left: solid 5px transparent;
-        border-top: solid 5px $lightest_blue;
+        border-top: solid 5px $border_color;
         transform: translateX(-50%);
         position: absolute;
         z-index: -1;
@@ -194,7 +194,7 @@
         top: unset;
         bottom: 100%;
         border-top: unset;
-        border-bottom: solid 5px #eefafe;
+        border-bottom: solid 5px $border_color;
     }
 }
 
@@ -205,7 +205,7 @@
         bottom: 100%;
         left: 20%;
         border-top: unset;
-        border-bottom: solid 5px #eefafe;
+        border-bottom: solid 5px $border_color;
     }
 }
 

--- a/solution/ui/regulations/css/scss/partials/_header.scss
+++ b/solution/ui/regulations/css/scss/partials/_header.scss
@@ -12,10 +12,10 @@ $header_input_height_wide: 40px;
     right: 0px;
     top: 40px;
     white-space: nowrap;
-    background: $lightest_gray;
+    background: $secondary_background_color;
     padding: 20px 30px;
     z-index: 1;
-    border: 1px solid $light_gray;
+    border: 1px solid $border_color;
     border-radius: 3px;
     box-shadow: 0px 0px 12px rgba(0, 0, 0, 0.25);
     -webkit-box-shadow: 0px 0px 12px rgba(0, 0, 0, 0.25);
@@ -78,7 +78,7 @@ header {
         @mixin header__anchor--active-bold {
             @include header__anchor--bold;
             color: $dark_gray;
-            border-bottom: 2px solid $dark_gray;
+            border-bottom: 2px solid $tertiary_border_color;
         }
 
         @mixin header__anchor--complete {
@@ -128,7 +128,7 @@ header {
 
             &--second {
                 height: 48px;
-                background: $lightest_blue;
+                background: $mid_red;
             }
         }
 
@@ -247,7 +247,7 @@ header {
                             .header--links__anchor {
                                 font-size: var(--font-size-md);
                                 line-height: 22px;
-                                color: $mid-gray;
+                                color: $hero_background_color;
                                 text-decoration: none;
                             }
                         }
@@ -368,7 +368,7 @@ header {
 
                     height: $header_input_height_wide;
                     width: 40px;
-                    border: 1px solid $light_gray;
+                    border: 1px solid $border_color;
                     border-left: none;
                     border-radius: 0 3px 3px 0;
 

--- a/solution/ui/regulations/css/scss/partials/_jump_to.scss
+++ b/solution/ui/regulations/css/scss/partials/_jump_to.scss
@@ -34,13 +34,13 @@ form .jump-to-input {
 
     input,
     select {
-        background-color: #fff;
-        border: 1px solid $light_gray;
+        background-color: $main_background_color;
+        border: 1px solid $border_color;
         height: 2rem;
     }
 
     input {
-        color: #000;
+        color:$primary_text_color;
 
         &.submit {
             display: inline-block;

--- a/solution/ui/regulations/css/scss/partials/_pagination.scss
+++ b/solution/ui/regulations/css/scss/partials/_pagination.scss
@@ -43,7 +43,7 @@ nav.pagination-controls {
                 text-decoration: none;
 
                 &:visited {
-                    color: $mid_blue;
+                    color: $visited_link_color;
                 }
             }
 
@@ -85,7 +85,7 @@ nav.pagination-controls {
         border: none;
         background: none;
         cursor: pointer;
-        color: $mid_blue;
+        color: $main_button_background;
         display: flex;
         align-items: center;
         justify-content: flex-end;
@@ -101,7 +101,7 @@ nav.pagination-controls {
         }
 
         &.disabled {
-            color: $mid_gray_3;
+            color: $main_button_disabled;
             cursor: default;
         }
     }

--- a/solution/ui/regulations/css/scss/partials/_reg_part_homepage.scss
+++ b/solution/ui/regulations/css/scss/partials/_reg_part_homepage.scss
@@ -28,7 +28,7 @@
     }
 
     h2 {
-        color: $primary_color;
+        color: $primary_text_color;
     }
 
     .last-updated {

--- a/solution/ui/regulations/css/scss/partials/_reg_text.scss
+++ b/solution/ui/regulations/css/scss/partials/_reg_text.scss
@@ -269,7 +269,7 @@
         max-width: var(--text-max-width);
         margin: var(--spacer-5) auto 10px !important;
         font-size: var(--font-size-sm);
-        color: $mid_gray;
+        color: $secondary_text_color;
 
         @include screen-xxl {
             padding: 0 0 0 10px;
@@ -429,8 +429,8 @@ article {
 }
 
 .btn{
-    background-color: $mid_blue;
-    color: white;
+    background-color: $main_button_background;
+    color: $main_button_color;
     border-radius: 3px;
     padding: 9px 10px 10px;
     border: none;
@@ -439,22 +439,22 @@ article {
 }
 
 .btn.inverted{
-    color: $mid_blue;
-    border: $mid_blue 2px solid;
-    background-color: white;
+    color: $primary_color;
+    border: $main_button_background 2px solid;
+    background-color: $main_background_color;
     font-weight: 700;
     font-size: 16px;
     line-height: 20px;
     text-align: center;
 }
 .btn.disabled{
-    background-color: #D6D7D9;
-    color: $dark_gray;
+    background-color: $main_button_disabled;
+    color: $secondary_text_color;
 }
 .bold{
     font-weight: 600;
     font-size: 14px;
 }
 .bold.disabled{
-    color: $mid_gray_3;
+    color: $secondary_text_color;
 }

--- a/solution/ui/regulations/css/scss/partials/_results_item.scss
+++ b/solution/ui/regulations/css/scss/partials/_results_item.scss
@@ -5,7 +5,7 @@
 @import "../application_settings";
 
 @mixin common-context-related-sections {
-    color: $mid_gray;
+    color: $tertiary_text_color;
     font-size: var(--font-size-sm);
     font-weight: 400;
     line-height: 22px;
@@ -22,8 +22,8 @@
 .doc-type__label {
     @include common-label-styles;
 
-    color: #fff;
-    background: $mid_gray;
+    color: $secondary_text_color;
+    background: $teritary_background_color;
 }
 
 .category-labels {
@@ -34,7 +34,7 @@
     .result-label {
         @include common-label-styles;
 
-        background: #e3eef9;
+        background: $reverse_background_darker;
 
         &.category-label,
         &.regulations-label {
@@ -42,8 +42,8 @@
         }
 
         &.regulations-label {
-            color: #fff;
-            background: $primary_color;
+            color: $reverse_text_color;
+            background: $reverse_background_color;
         }
     }
 }
@@ -69,7 +69,7 @@
 
             &--bar {
                 padding-right: 8px;
-                border-right: 1px solid $mid_gray;
+                border-right: 1px solid $border_color;
             }
         }
 
@@ -78,7 +78,7 @@
 
             &--bar {
                 padding-left: 8px;
-                border-left: 1px solid $mid_gray;
+                border-left: 1px solid $border_color;
             }
         }
     }
@@ -144,7 +144,7 @@
     .title__span,
     .section-sign,
     .pipe-separator {
-        color: $mid_gray;
+        color: $secondary_text_color;
         font-size: 14px;
     }
 
@@ -169,12 +169,12 @@
 
     .related-sections {
         margin-bottom: 40px;
-        color: $mid_gray;
+        color: $secondary_text_color;
         font-size: $font-size-xs;
 
         .related-sections-title {
             font-weight: 600;
-            color: $dark_gray;
+            color: $secondary_text_color;
             text-transform: none;
             font-size: $font-size-xs;
         }

--- a/solution/ui/regulations/css/scss/partials/_search.scss
+++ b/solution/ui/regulations/css/scss/partials/_search.scss
@@ -12,7 +12,7 @@
 .v-overlay__content {
     .subjects__select-container {
         &--menu {
-            background-color: white;
+            background-color: $main_background_color;
             max-height: 300px;
 
             .subjects__list-container {
@@ -144,7 +144,7 @@
 // SEARCH INPUT -----------------
 
 .search-field {
-    background-color: #fff;
+    background-color: $main_background_color;
 
     input {
         margin-block-start: 0;
@@ -231,7 +231,7 @@
         line-height: 1.5rem;
         font-weight: bold;
         text-transform: capitalize;
-        background-color: $lightest_gray;
+        background-color: $secondary_background_color;
         margin-block-start: 0;
         margin-block-end: 0;
     }
@@ -239,7 +239,7 @@
     .research__row {
         display: flex;
         font-size: var(--font-size-md);
-        border: 1px solid $light_gray;
+        border: 1px solid $border_color;
         border-top: unset;
 
         .row__title {

--- a/solution/ui/regulations/css/scss/partials/_sidebar_left.scss
+++ b/solution/ui/regulations/css/scss/partials/_sidebar_left.scss
@@ -90,7 +90,7 @@ aside.left-sidebar {
     .subpart-name {
         font-size: var(--font-size-sm);
         font-weight: normal;
-        color: $reverse_text_color;
+        color: $secondary_text_color;
         padding-right: var(--spacer-4);
     }
 
@@ -111,7 +111,7 @@ aside.left-sidebar {
     }
 
     .toc-section-name {
-        color: $reverse_text_color;
+        color: $secondary_text_color;
         font-weight: normal;
         font-size: var(--font-size-sm);
     }
@@ -124,7 +124,7 @@ aside.left-sidebar {
 
         background: none;
         border: none;
-        color: #ccf2ff;
+        color: $secondary_link_color;
         cursor: pointer;
         display: flex;
         justify-content: center;
@@ -134,8 +134,8 @@ aside.left-sidebar {
 
         &:hover,
         &:focus {
-            color: $reverse_link_hover;
-            background: $reverse_background_lighter;
+            color: $secondary_link_hover;
+            background: $secondary_background_active;
             @include transition;
         }
     }
@@ -154,10 +154,10 @@ aside.left-sidebar {
             //overflow: hidden;
 
             &.active {
-                background: $reverse_background_darker;
+                background: $secondary_background_active;
 
                 .subpart-info {
-                    color: $reverse_text_color;
+                    color: $secondary_text_color;
                 }
             }
 
@@ -180,12 +180,12 @@ aside.left-sidebar {
     }
 
     a {
-        color: #ccf2ff;
+        color: $secondary_link_color;
 
         &:hover,
         &:focus {
-            color: $reverse_link_hover;
-            background: $reverse_background_lighter;
+            color: $secondary_link_hover;
+            background: $secondary_background_active;
         }
 
         &.subpart-info {
@@ -195,7 +195,7 @@ aside.left-sidebar {
             &:hover,
             &:focus {
                 .toc-titles {
-                    background: $reverse_background_lighter;
+                    background: $secondary_background_active;
                     @include transition;
                 }
             }
@@ -215,13 +215,13 @@ aside.left-sidebar {
         &:not(li.active ul a.menu-section) {
             &:hover,
             &:focus {
-                background: $reverse_background_lighter;
+                background: $secondary_background_active;
             }
         }
 
         &.active {
-            background: $reverse_background_lighter;
-            border-left-color: $light_blue;
+            background: $secondary_background_active;
+            border-left-color: $tertiary_border_color;
             border-left-style: solid;
         }
 
@@ -232,15 +232,15 @@ aside.left-sidebar {
 
     li.active ul a.menu-section:hover,
     li.active ul a.menu-section:focus {
-        background: $reverse_background_lighter;
+        background: $secondary_background_active;
     }
 }
 
 .toc-header {
-    border-bottom: 1px solid $secondary_border_color;
+    border-bottom: 1px solid $tertiary_border_color;
     margin: 25px 40px 16px 32px;
     padding-bottom: 16px;
-    color: white;
+    color: $secondary_text_color;
 
     .toc-subchapter {
         font-size: 14px;
@@ -262,7 +262,7 @@ aside.left-sidebar {
 
 .toc-controls {
     box-sizing: border-box;
-    border-bottom: 1px solid $secondary_border_color;
+    border-bottom: 1px solid $tertiary_border_color;
 
     button {
         outline: none;

--- a/solution/ui/regulations/css/scss/partials/_sidebar_right.scss
+++ b/solution/ui/regulations/css/scss/partials/_sidebar_right.scss
@@ -190,7 +190,7 @@ button.collapsible-title {
 }
 
 .childless {
-    color: $mid_gray_3;
+    color: $primary_text_color;
 }
 
 .show-more-button {

--- a/solution/ui/regulations/css/scss/partials/_sidebar_right.scss
+++ b/solution/ui/regulations/css/scss/partials/_sidebar_right.scss
@@ -172,7 +172,7 @@ button.collapsible-title {
     }
 
     &.visible {
-        color: $dark-gray;
+        color: $primary_text_color;
 
         i.fa {
             color: $primary_link_color;

--- a/solution/ui/regulations/css/scss/partials/_statutes.scss
+++ b/solution/ui/regulations/css/scss/partials/_statutes.scss
@@ -43,11 +43,11 @@
                     margin: 0 0 12px;
 
                     &.acts-item__heading {
-                        color: $mid_blue;
+                        color: $secondary_link_color;
                         transition: none;
 
                         &--active {
-                            color: $dark_gray;
+                            color: $secondary_link_hover;
                         }
                     }
                 }
@@ -66,8 +66,8 @@
                     &:hover,
                     &:focus,
                     &--active {
-                        color: $dark_gray;
-                        border-bottom: 1px solid $dark_gray;
+                        color: $secondary_link_hover;
+                        border-bottom: 1px solid $secondary_link_hover;
                     }
 
                     &--loading {
@@ -203,8 +203,8 @@
                         }
 
                         &--header {
-                            background-color: $mid_blue_2;
-                            color: #fff;
+                            background-color: $table_header_background_color;
+                            color: $primary_text_color;
                             text-align: left;
                             vertical-align: top;
                         }
@@ -230,7 +230,7 @@
                     }
 
                     .row__cell--body.row__cell--primary {
-                        background-color: $lightest_blue;
+                        background-color: $secondary_background_color;
                     }
                 }
             }

--- a/solution/ui/regulations/css/scss/partials/_subjects.scss
+++ b/solution/ui/regulations/css/scss/partials/_subjects.scss
@@ -15,7 +15,7 @@
     &:hover,
     &:focus,
     &:active {
-        background-color: #c0c1c3;
+        background-color: $policy_subject_close_background_hover;
     }
 
     i {
@@ -35,7 +35,8 @@
         .ds-c-choice-wrapper {
             padding: 8px;
             margin-top: 0;
-            border: 1px solid $secondary_border_color;
+            border: 1px solid $tertiary_border_color;
+;
             border-radius: 4px;
 
             .ds-c-choice--small + label::before {
@@ -47,8 +48,8 @@
             }
 
             .ds-c-choice:checked + label::before {
-                background-color: $secondary_border_color;
-                border-color: $secondary_border_color;
+                background-color: $choice-checked-background-color;
+                border-color: $$choice-checked-border-color;
             }
 
             input {
@@ -136,7 +137,7 @@
 
         &::after {
             box-sizing: border-box;
-            border: 2px solid $secondary_border_color !important;
+            border: 2px solid $tertiary_border_color !important;
         }
 
         &[aria-expanded="true"]::after,
@@ -160,14 +161,14 @@
 
                 .v-field__outline {
                     > * {
-                        border-color: $secondary_border_color;
+                        border-color: $tertiary_border_color;
                     }
                 }
             }
 
             .v-field--focused {
                 .v-field__outline > * {
-                    border-color: $secondary_border_color;
+                    border-color: $tertiary_border_color;
                 }
             }
 
@@ -572,7 +573,7 @@
 
         &:hover,
         &:focus {
-            background-color: #e7f4fa;
+            background-color: $main_button_hover_background;
         }
     }
 }

--- a/solution/ui/regulations/css/scss/partials/_subjects_selector.scss
+++ b/solution/ui/regulations/css/scss/partials/_subjects_selector.scss
@@ -47,7 +47,7 @@
         }
 
         .subjects__input--sidebar {
-            background-color: white;
+            background-color: $main_background_color;
             position: sticky;
             top: 0px;
         }
@@ -128,7 +128,7 @@
 
             .subjects-li__button {
                 text-align: left;
-                color: #000;
+                color: $primary_text_color;
                 width: 100%;
 
                 &--selected {

--- a/solution/ui/regulations/css/scss/partials/_supplemental_content.scss
+++ b/solution/ui/regulations/css/scss/partials/_supplemental_content.scss
@@ -24,7 +24,7 @@
             left: 0;
             width: 15px;
             height: 20px;
-            border: solid $light_gray;
+            border: solid $border_color;
             border-width: 0 0 1px 1px;
         }
     }
@@ -137,7 +137,7 @@
     }
 
     .supplemental-content-mid-bar {
-        border-right: 1px solid black;
+        border-right: 1px solid $tertiary_border_color;
     }
 
     .supplemental-content-title {
@@ -216,7 +216,7 @@
     .supplemental-content-category {
         &:not(:last-child) {
             margin-bottom: 1em;
-            border-bottom: 1px solid $light-gray;
+            border-bottom: 1px solid $border_color;
         }
     }
 }

--- a/solution/ui/regulations/css/scss/partials/_typography.scss
+++ b/solution/ui/regulations/css/scss/partials/_typography.scss
@@ -12,7 +12,7 @@ html {
 }
 
 body {
-    background-color: $white;
+    background-color: $main_background_color;
     color: $primary_text_color;
     font-family: $primary_site_font;
     line-height: var(--font-line-height-base);


### PR DESCRIPTION
Major first update to site styles so that Policy Connector can have a standalone visual identity

- Replaces previous site colors with new ones pulled from new design file 
- Makes later changes easier by replacing hard-coded values with tokens defined in _application_settings wherever possible. 

To verify, check colors on site against Figma
