### PR TITLE
Update domain references from eregulations.cms.gov to policyconnector.digital

### DIFF
--- a/solution/backend/cmcs_regulations/context_processors.py
+++ b/solution/backend/cmcs_regulations/context_processors.py
@@ -18,7 +18,7 @@ def custom_url(request):
     custom_url = settings.CUSTOM_URL
     host = request.get_host()
 
-    if host == 'eregulations.cms.gov':
+    if host == 'policyconnector.digital':
         custom_url = host
 
     return {'CUSTOM_URL': custom_url}

--- a/solution/backend/redirect_lambda.py
+++ b/solution/backend/redirect_lambda.py
@@ -3,7 +3,7 @@ from urllib.parse import urljoin
 
 def handler(event, context):
     original_path = event['path']
-    new_domain = 'https://eregulations.cms.gov'
+    new_domain = 'https://policyconnector.digital'
     new_url = urljoin(new_domain, original_path)
 
     response = {

--- a/solution/backend/regulations/tests/test_context_processors.py
+++ b/solution/backend/regulations/tests/test_context_processors.py
@@ -9,14 +9,14 @@ class CustomUrlContextProcessorTest(TestCase):
     def test_custom_url_no_match_request(self):
         # domain the request is being made from
         request = HttpRequest()
-        request.META['HTTP_HOST'] = 'eregulations.cms.gov'
+        request.META['HTTP_HOST'] = 'policyconnector.digital'
 
         # custom_url the environment variable is set as.
         settings.CUSTOM_URL = 'regulations-pilot.cms.gov'
 
         context = custom_url(request)
 
-        self.assertEqual(context['CUSTOM_URL'], 'eregulations.cms.gov')
+        self.assertEqual(context['CUSTOM_URL'], 'policyconnector.digital')
 
     def test_custom_url_match_request(self):
         request = HttpRequest()

--- a/solution/ui/regulations/eregs-vite/src/router/index.js
+++ b/solution/ui/regulations/eregs-vite/src/router/index.js
@@ -25,7 +25,7 @@ const routes = [
 const router = ({ customUrl = "", host = "" }) =>
     createRouter({
         history: createWebHistory(
-            import.meta.env.VITE_ENV === "prod" && host === customUrl
+            import.meta.env.VITE_ENV === "prod"
                 ? "/"
                 : import.meta.env.VITE_ENV || "/"
         ),


### PR DESCRIPTION
Update domain references from eregulations.cms.gov to policyconnector.digital