### PR TITLE
Update header navigation

### DIFF
--- a/solution/ui/regulations/eregs-vite/src/components/AccessLink.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/AccessLink.vue
@@ -9,9 +9,9 @@ const props = defineProps({
     },
 });
 
-const getAccessUrl = computed(() => `${props.base}get-account-access/`);
+const getAccessUrl = computed(() => `${props.base}about/`);
 
-const isActive = window.location.pathname.includes("get-account-access");
+const isActive = window.location.pathname.includes("about");
 
 const propsObj = {
     active: isActive,
@@ -24,12 +24,12 @@ const propsObj = {
         v-bind="propsObj"
         name="get-account-access-narrow"
         class="header__access-link header__access-link--narrow"
-        label="Placeholder"
+        label="About"
     />
     <HeaderLink
         v-bind="propsObj"
         name="get-account-access-wide"
         class="header__access-link header__access-link--wide"
-        label="Placeholder"
+        label="About"
     />
 </template>

--- a/solution/ui/regulations/eregs-vite/src/components/SignInLink.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/SignInLink.vue
@@ -45,7 +45,7 @@ const linkClasses = computed(() => ({
 }));
 </script>
 
-<template>
+<!--<template>
     <template v-if="location === 'login_page'">
         <span class="disabled">{{ linkLabel }}</span>
     </template>
@@ -60,4 +60,4 @@ const linkClasses = computed(() => ({
     </template>
 </template>
 
-<style></style>
+<style></style>-->


### PR DESCRIPTION
Hide the sign in link (not relevant for this instance) and stick the "about" link at top right.