### PR TITLE
Add copy to EO landing page

### DIFF
--- a/solution/ui/regulations/css/scss/partials/_subjects.scss
+++ b/solution/ui/regulations/css/scss/partials/_subjects.scss
@@ -436,8 +436,10 @@
         }
 
         ul {
-            margin-top: 0px;
-            padding-bottom: 0px;
+            /*margin-top: 0px;
+            padding-bottom: 0px;*/
+            
+            a { text-decoration: none; }
         }
     }
 

--- a/solution/ui/regulations/eregs-vite/src/components/subjects/SubjectLanding.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/subjects/SubjectLanding.vue
@@ -14,7 +14,19 @@ const $route = useRoute();
 
 <template>
     <div class="subj-landing__container">
-    <p>TBD</p>
+    <h1>Research Executive Actions</h1>
+    
+    <p><strong>Pick an Executive Order or Memo</strong> to find related guidance, statutes, and prior Executive Orders.</p>
+    
+    <span>Or browse by category:</span>
+    <ul>
+    	<li><a href="?categories=9">Court Cases</a></li>
+    	<li><a href="?categories=5">Executive Orders and Memos</a></li>
+    	<li><a href="?categories=11">OPM Memos</a></li>
+    	<li><a href="?categories=10">OPM Publications</a></li>
+    	<li><a href="?categories=13">Merit Systems Protection Board Publications</a></li>
+    	<li><a href="?categories=2">Congressional Research Reports</a></li>
+    </ul>
     </div>
 </template>
 

--- a/solution/ui/regulations/eregs-vite/src/components/subjects/SubjectSelector.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/subjects/SubjectSelector.vue
@@ -298,7 +298,7 @@ const liDownArrowPress = (event) => {
                 </div>
             </template>
             <template v-else>
-                <div :class="inputContainerClasses">
+                <!--<div :class="inputContainerClasses">
                     <form @submit.prevent>
                         <input
                             id="subjectReduce"
@@ -329,7 +329,7 @@ const liDownArrowPress = (event) => {
                             )
                         "
                     />
-                </div>
+                </div>-->
                 <ul tabindex="-1" class="subjects__list">
                     <li
                         v-for="subject in state.subjects"

--- a/solution/ui/regulations/eregs-vite/src/components/subjects/SubjectSelector.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/subjects/SubjectSelector.vue
@@ -298,8 +298,8 @@ const liDownArrowPress = (event) => {
                 </div>
             </template>
             <template v-else>
-                <!--<div :class="inputContainerClasses">
-                    <form @submit.prevent>
+                <div :class="inputContainerClasses">
+                    <!--<form @submit.prevent>
                         <input
                             id="subjectReduce"
                             v-model="state.filter"
@@ -308,7 +308,7 @@ const liDownArrowPress = (event) => {
                             type="text"
                             @keydown.up.prevent="inputUpArrowPress"
                             @keydown.down.prevent="inputDownArrowPress"
-                        >
+                        
                         <button
                             aria-label="Clear subject list filter"
                             data-testid="clear-subject-filter"
@@ -318,7 +318,7 @@ const liDownArrowPress = (event) => {
                             @keydown.enter="filterResetClick"
                             @click="filterResetClick"
                         />
-                    </form>
+                    </form>-->
                     <slot
                         name="selection"
                         :selected-subject="
@@ -329,7 +329,7 @@ const liDownArrowPress = (event) => {
                             )
                         "
                     />
-                </div>-->
+                </div>
                 <ul tabindex="-1" class="subjects__list">
                     <li
                         v-for="subject in state.subjects"

--- a/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
@@ -393,7 +393,7 @@ getDocSubjects();
                     </button>
                     <PolicySidebar>
                         <template #title>
-                            <h2>Research an EO</h2>
+                            <h2>Find Policy</h2>
                         </template>
                         <template #filters>
                             <SubjectSelector


### PR DESCRIPTION
Changes to topic-lookup page:

* Remove "Find a subject" filter from left navigation
* Add hardcoded copy to homepage, including links to view all items in selected categories