### PR TITLE
More search

### DIFF
--- a/solution/text-extractor/extractors/markup.py
+++ b/solution/text-extractor/extractors/markup.py
@@ -33,12 +33,12 @@ class MarkupExtractor(Extractor):
 
             # Primary content extraction strategy - common patterns across gov sites
 
-            # 1. Try to find main content container by ID
-            for main_id in ["main-main-content", "DeltaPlaceHolderMain", "mainContent", "main-content"]:
+            # 1. Try to find main content container by ID. docViewer is for uscode.house.gov
+            for main_id in ["main-main-content", "DeltaPlaceHolderMain", "mainContent", "main-content", "MainContentDiv", "SpecialContentContainer", "content", "docViewer", "MainContent_Container"]:
                 main_content = extractor.find(id=main_id)
                 if main_content:
                     # If it contains a "body-content" section, use that
-                    body_content = main_content.find(class_="body-content") or main_content.find(class_="ms-rtestate-field")
+                    body_content = main_content.find(class_="body-content")  # body-content is because OPM.gov puts a huge nav in its <main>
                     if body_content:
                         return self._clean_extracted_text(body_content.get_text(" "))
                     return self._clean_extracted_text(main_content.get_text(" "))
@@ -61,7 +61,7 @@ class MarkupExtractor(Extractor):
                 return self._clean_extracted_text(article_tag.get_text(" "))
 
             # 3. Try common content container classes
-            for content_class in ["body-content", "entry-content", "ContentPlaceHolder", "contentBox", "contentContainer", "main-content", "content", "region-content", "ms-rtestate-field"]:
+            for content_class in ["body-content", "entry-content", "ContentPlaceHolder", "contentBox", "contentContainer", "main-content", "content", "region-content", "ms-rtestate-field", "umb-block-list"]:
                 content_div = extractor.find(class_=lambda c: c and content_class in str(c).lower())
                 if content_div:
                     return self._clean_extracted_text(content_div.get_text(" "))

--- a/solution/text-extractor/extractors/text.py
+++ b/solution/text-extractor/extractors/text.py
@@ -1,11 +1,23 @@
 from bs4 import UnicodeDammit
 
 from .extractor import Extractor
+from .markup_extractor import MarkupExtractor  # Import existing markup extractor
 
+# Modified with the help of a LLM to use the markup extractor if it's not really a text file
 
 class TextExtractor(Extractor):
     file_types = ("txt",)
 
     def _extract(self, file: bytes) -> str:
+        # Convert bytes to string with proper encoding detection
         extractor = UnicodeDammit(file)
-        return extractor.unicode_markup
+        text = extractor.unicode_markup
+
+        # Check if the text looks like HTML
+        if text.strip().startswith('<') and ('</html>' in text.lower() or '</body>' in text.lower() or '<div' in text.lower()):
+            # This looks like HTML, use the markup extractor instead
+            markup_extractor = MarkupExtractor()
+            return markup_extractor._extract(file)
+
+        # Regular text file, return as is
+        return text

--- a/solution/text-extractor/text_extractor.py
+++ b/solution/text-extractor/text_extractor.py
@@ -82,6 +82,9 @@ def handler(event: dict, context: dict) -> dict:
     try:
         extractor = Extractor.get_extractor(file_type, config)
         text = extractor.extract(file)
+        # Log the first ~200 characters of extracted text
+        preview = text[:200].replace('\n', ' ').replace('\r', '')
+        logger.info(f"Extracted text preview: '{preview}...'")
     except ExtractorInitException as e:
         return lambda_failure(500, f"Failed to initialize text extractor: {str(e)}")
     except ExtractorException as e:


### PR DESCRIPTION
Followup to #53 and #55. Changes to improve extraction:

* If page detected as text is really html, use markup extractor
* Handle weird OPM pages in markup filter
* Log first 200 characters of extracted text