### PR TITLE
Enable viewing resources on mobile

### DIFF
--- a/solution/ui/regulations/css/scss/_layout.scss
+++ b/solution/ui/regulations/css/scss/_layout.scss
@@ -226,4 +226,3 @@ footer {
 .display-none {
     display: none !important;
 }
-

--- a/solution/ui/regulations/css/scss/_layout.scss
+++ b/solution/ui/regulations/css/scss/_layout.scss
@@ -226,3 +226,11 @@ footer {
 .display-none {
     display: none !important;
 }
+
+/* LLM code */
+.reg-text.match-middle {
+    @include custom-max(calc($mobile-max / 1px)) {
+        width: 100%;
+        padding: 0 var(--spacer-3);
+    }
+}

--- a/solution/ui/regulations/css/scss/_layout.scss
+++ b/solution/ui/regulations/css/scss/_layout.scss
@@ -43,13 +43,18 @@ body {
 .flexbox {
     display: flex;
     width: 100%;
+    
+    /* Remove any existing grid code and use this instead; LLM code */
+    @include custom-max(calc($mobile-max / 1px)) {
+        flex-direction: column;
+    }
 }
 
 .match-sides {
     &[data-state="collapsed"] {
         flex: 0 0 $collapsed-sidebar-width;
     }
-
+    
     @include screen-md {
         flex: 0 0 275px;
     }
@@ -80,6 +85,11 @@ aside {
         background: $secondary_background_color;
         padding: 0;
         flex-shrink: 0;
+        
+        /* Hide on mobile; LLM code */
+        @include custom-max(calc($mobile-max / 1px)) {
+            display: none;
+        }
     }
 
     &.right-sidebar {
@@ -91,7 +101,14 @@ aside {
         }
 
         @include custom-max(calc($mobile-max / 1px)) {
-            display: none;
+            /*display: none;*/
+            /* LLM code */
+            display: block;
+            width: 100%;
+            border-left: none;
+            border-top: 1px solid $border_color;
+            margin-top: var(--spacer-3);
+            padding-top: var(--spacer-3);
         }
     }
 
@@ -208,4 +225,12 @@ footer {
 
 .display-none {
     display: none !important;
+}
+
+/* LLM code */
+.reg-text.match-middle {
+    @include custom-max(calc($mobile-max / 1px)) {
+        width: 100%;
+        padding: 0 var(--spacer-3);
+    }
 }

--- a/solution/ui/regulations/css/scss/_layout.scss
+++ b/solution/ui/regulations/css/scss/_layout.scss
@@ -44,7 +44,7 @@ body {
     display: flex;
     width: 100%;
     
-    /* Remove any existing grid code and use this instead; LLM code */
+    /* To enable viewing resources on mobile; LLM code */
     @include custom-max(calc($mobile-max / 1px)) {
         flex-direction: column;
     }
@@ -54,7 +54,7 @@ body {
     &[data-state="collapsed"] {
         flex: 0 0 $collapsed-sidebar-width;
     }
-    
+
     @include screen-md {
         flex: 0 0 275px;
     }
@@ -86,7 +86,7 @@ aside {
         padding: 0;
         flex-shrink: 0;
         
-        /* Hide on mobile; LLM code */
+        /* Hide left nav on mobile; LLM code */
         @include custom-max(calc($mobile-max / 1px)) {
             display: none;
         }
@@ -102,7 +102,7 @@ aside {
 
         @include custom-max(calc($mobile-max / 1px)) {
             /*display: none;*/
-            /* LLM code */
+            /* Show resources at bottom of page on mobile; LLM code */
             display: block;
             width: 100%;
             border-left: none;
@@ -227,10 +227,3 @@ footer {
     display: none !important;
 }
 
-/* LLM code */
-.reg-text.match-middle {
-    @include custom-max(calc($mobile-max / 1px)) {
-        width: 100%;
-        padding: 0 var(--spacer-3);
-    }
-}

--- a/solution/ui/regulations/css/scss/partials/_sidebar_right.scss
+++ b/solution/ui/regulations/css/scss/partials/_sidebar_right.scss
@@ -25,8 +25,8 @@ aside.right-sidebar {
         position: static; /* Remove sticky positioning on mobile */
         overflow: visible; /* No need for scrolling when height is auto */
         max-width: 100%; /* Full width on mobile */
-        width: calc(100% - 56px); // Adds margin on each side
-        margin: 0 auto; // Centers the sidebar
+        width: calc(100% - 56px); /* Adds margin on each side */
+        margin: 0 auto; /* Centers the sidebar */
     }
 
     h1 {

--- a/solution/ui/regulations/css/scss/partials/_sidebar_right.scss
+++ b/solution/ui/regulations/css/scss/partials/_sidebar_right.scss
@@ -17,6 +17,15 @@ aside.right-sidebar {
     @include screen-lg {
         height: calc(100vh - #{$header_height} - #{var(--spacer-5)});
     }
+    
+    /* LLM code */
+    @include custom-max(calc($mobile-max / 1px)) {
+        height: auto; /* Let content determine height on mobile */
+        max-height: none; /* Remove any max height constraints */
+        position: static; /* Remove sticky positioning on mobile */
+        overflow: visible; /* No need for scrolling when height is auto */
+        max-width: 100%; /* Full width on mobile */
+    }
 
     h1 {
         font-size: calc(var(--font-size-base) * 1.4);

--- a/solution/ui/regulations/css/scss/partials/_sidebar_right.scss
+++ b/solution/ui/regulations/css/scss/partials/_sidebar_right.scss
@@ -25,6 +25,8 @@ aside.right-sidebar {
         position: static; /* Remove sticky positioning on mobile */
         overflow: visible; /* No need for scrolling when height is auto */
         max-width: 100%; /* Full width on mobile */
+        width: calc(100% - 56px); // Adds margin on each side
+        margin: 0 auto; // Centers the sidebar
     }
 
     h1 {

--- a/solution/ui/regulations/eregs-component-lib/src/components/ViewResourcesLink.vue
+++ b/solution/ui/regulations/eregs-component-lib/src/components/ViewResourcesLink.vue
@@ -55,10 +55,19 @@ export default {
     },
     methods: {
         clickHandler() {
+            // Emit the existing event
             eventbus.emit(EventCodes.SetSection, {
                 section: this.section,
                 count: this.count,
             });
+            
+            // Scroll to resources section on mobile; LLM code
+            if (window.innerWidth < 767) {
+                const resourcesHeading = document.querySelector('#right-sidebar');
+                if (resourcesHeading) {
+                    resourcesHeading.scrollIntoView({ behavior: 'smooth' });
+                }
+            }
         },
         isLink() {
             return this.type === "link";

--- a/solution/ui/regulations/eregs-component-lib/src/components/ViewResourcesLink.vue
+++ b/solution/ui/regulations/eregs-component-lib/src/components/ViewResourcesLink.vue
@@ -55,7 +55,6 @@ export default {
     },
     methods: {
         clickHandler() {
-            // Emit the existing event
             eventbus.emit(EventCodes.SetSection, {
                 section: this.section,
                 count: this.count,


### PR DESCRIPTION
Changes on reg reading pages on mobile screen sizes:

* Hide left navigation (it had a mobile experience, but it's too complicated to try to keep that if we want to make "view resources" work)
* Show resources at the bottom
* When you click "view resources", scroll to the bottom

This isn't great because there's no option to jump back to the section you were reading, but at least it's better than nothing.