### PR TITLE
Hide footer update date for regs

### DIFF
--- a/solution/backend/regulations/templates/regulations/partials/footer.html
+++ b/solution/backend/regulations/templates/regulations/partials/footer.html
@@ -17,7 +17,7 @@
         <p><em>For the moment, this site works best on desktop browsers.</em></p>
     </div>
     <div class="footer-right match-sides">
-        <h4 class="ds-text-heading--md last-update-footer">
+        <!--<h4 class="ds-text-heading--md last-update-footer">
             Regulations up to date from <a href="https://www.ecfr.gov" target="_blank" rel="noopener noreferrer" class="external">
                 eCFR
             </a> as of
@@ -28,7 +28,7 @@
                         <last-parser-success-date api-url={{ API_BASE }} ></last-parser-success-date>
                     </span>.
                 {% endif %}
-        </h4>
+        </h4>-->
         <div class="about-footer">
         	<p><strong><a href="{% url 'about' %}">About + Contact Us</a></strong></p>
         	<p><a href="https://github.com/A1MSolutions/policyconnector" class="external" target="_blank" rel="noopener noreferrer">Open source code repository</a></p>


### PR DESCRIPTION
This doesn't work well with multiple titles. Better to look at the dates on the individual reg pages.