### PR TITLE
Add go-back button for viewing resources

### DIFF
--- a/solution/ui/regulations/eregs-component-lib/src/components/SupplementalContent.vue
+++ b/solution/ui/regulations/eregs-component-lib/src/components/SupplementalContent.vue
@@ -46,6 +46,16 @@
 			({{ resourceCount }})
 		</a>
 	</div>
+	<!-- New go-back button, only show if scrollOrigin is set; LLM code -->
+	<button
+		v-if="hasScrolled"
+		class="btn"
+		@click="goBack"
+	>
+		<div class="view-resources-link">
+			<span class="bold">Go back to regulation</span>
+		</div>
+	</button>
     <!-- end of LLM code -->
 </template>
 
@@ -130,6 +140,9 @@ export default {
             selectedPart: undefined,
             resourceCount: 0,
             partDict: {},
+            // To support go-back button; LLM code
+            scrollOrigin: null,
+            hasScrolled: false
         };
     },
 
@@ -181,10 +194,14 @@ export default {
         eventbus.on(EventCodes.SetSection, (args) => {
             this.selectedPart = args.section;
         });
+        // Add listener for scroll tracking; LLM code
+        eventbus.on(EventCodes.TrackScrollOrigin, this.handleScrollTracking);
         this.categories = getDefaultCategories();
     },
     beforeUnmount() {
         eventbus.off(EventCodes.SetSection);
+        // Remove the scroll tracking listener; LLM code
+        eventbus.off(EventCodes.TrackScrollOrigin, this.handleScrollTracking);
     },
     unmounted() {
         window.removeEventListener("hashchange", this.handleHashChange);
@@ -318,6 +335,26 @@ export default {
 		},
         /*  end of LLM code*/        
         
+        /* start of more LLM code */
+        // New method to handle scroll tracking
+        handleScrollTracking(data) {
+            this.scrollOrigin = data.origin;
+            this.hasScrolled = true;
+        },
+
+        // New method to handle going back
+        goBack() {
+            if (this.scrollOrigin !== null) {
+                window.scrollTo({
+                    top: this.scrollOrigin,
+                    behavior: 'smooth'
+                });
+                // Reset the origin and scrolled state after scrolling back
+                this.scrollOrigin = null;
+                this.hasScrolled = false;
+            }
+        },
+        /*  end of more LLM code*/
         
         clearSection() {
             this.selectedPart = undefined;

--- a/solution/ui/regulations/eregs-component-lib/src/components/ViewResourcesLink.vue
+++ b/solution/ui/regulations/eregs-component-lib/src/components/ViewResourcesLink.vue
@@ -38,6 +38,15 @@ import eventbus from "../eventbus";
 export default {
     name: "ViewResourcesLink",
 
+    /* Start LLM code */
+    data() {
+        return {
+            scrollOrigin: null,
+            hasScrolled: false
+        };
+    },
+    /* End LLM code */
+
     props: {
         section: {
             type: String,
@@ -54,12 +63,21 @@ export default {
         },
     },
     methods: {
+    /* Start partially LLM code */
         clickHandler() {
+            // Store the current scroll position before navigating
+            const scrollOrigin = window.pageYOffset;
+
+            // Emit an event with the scroll origin
+            eventbus.emit(EventCodes.TrackScrollOrigin, {
+                origin: scrollOrigin
+            });
+
             eventbus.emit(EventCodes.SetSection, {
                 section: this.section,
                 count: this.count,
             });
-            
+
             // Scroll to resources section on mobile; LLM code
             if (window.innerWidth < 767) {
                 const resourcesHeading = document.querySelector('#right-sidebar');
@@ -68,6 +86,18 @@ export default {
                 }
             }
         },
+        goBack() {
+            if (this.scrollOrigin !== null) {
+                window.scrollTo({
+                    top: this.scrollOrigin,
+                    behavior: 'smooth'
+                });
+                // Reset the origin and scrolled state after scrolling back
+                this.scrollOrigin = null;
+                this.hasScrolled = false;
+            }
+        },
+        /* End partially LLM code */
         isLink() {
             return this.type === "link";
         },

--- a/solution/ui/regulations/eregs-component-lib/src/components/ViewResourcesLink.vue
+++ b/solution/ui/regulations/eregs-component-lib/src/components/ViewResourcesLink.vue
@@ -78,7 +78,7 @@ export default {
                 count: this.count,
             });
 
-            // Scroll to resources section on mobile; LLM code
+            // Scroll to resources section, using width defined in $mobile-max in _application_settings.scss; LLM code
             if (window.innerWidth < 767) {
                 const resourcesHeading = document.querySelector('#right-sidebar');
                 if (resourcesHeading) {

--- a/solution/ui/regulations/utilities/utils.js
+++ b/solution/ui/regulations/utilities/utils.js
@@ -9,6 +9,8 @@ import lodashGet from "lodash/get";
 const EventCodes = {
     SetSection: "SetSection",
     ClearSections: "ClearSections",
+    // For go-back on reg sidebars; LLM code
+    TrackScrollOrigin: "TrackScrollOrigin",
 };
 
 const DOCUMENT_TYPES = ["regulations", "external", "internal"];


### PR DESCRIPTION
This is a followup to #59. It allows you to jump back to the regulation you were reading after you scroll to the bottom to see resources.