### PR TITLE
Make full titles display for regs in search results

### DIFF
--- a/solution/backend/content_search/models.py
+++ b/solution/backend/content_search/models.py
@@ -131,7 +131,7 @@ class ContentIndexQuerySet(models.QuerySet):
                 config='english',
                 highlight_all=True,
                 fragment_delimiter='...',
-                max_fragments=self._max_fragments,
+                max_fragments=None,  # Fragment setting should only apply to content
             ),
             content_headline=SearchHeadline(
                 "content_short",


### PR DESCRIPTION
Followup to #72 - that fixed search result headlines for resources, but regs are separate.