### PR TITLE
Ignore subparts with bad data in sitemap creation

### DIFF
--- a/solution/backend/regulations/sitemap.py
+++ b/solution/backend/regulations/sitemap.py
@@ -50,8 +50,11 @@ class PartSitemap(Sitemap):
         return obj['last_updated']
 
     def location(self, item):
+    try:
         kwargs = {}
         for key in ['title', 'part', 'subpart']:
             if item.get(key):
                 kwargs[key] = item[key]
         return reverse("reader_view", kwargs=kwargs)
+    except:
+        return None


### PR DESCRIPTION
5 CFR 316 Subpart I currently has a data problem, which is making the sitemap not work (500 error). This is a way to skip that subpart while generating the sitemap.