### PR TITLE
Part appendix

### DIFF
--- a/solution/backend/regulations/converters.py
+++ b/solution/backend/regulations/converters.py
@@ -16,3 +16,19 @@ class SubpartConverter(PathConverter):
 
 class VersionConverter(PathConverter):
     regex = r'[\d\w]+-[\d\w]+(?:-\d+)?'
+
+
+class AppendixConverter(PathConverter):
+    # This will match almost any appendix format by looking for
+    # "Appendix" at the start, followed by anything that doesn't include a slash
+    regex = r'Appendix[^/]+'
+
+    def to_python(self, value):
+        # Convert dash-separated URL format back to list
+        parts = value.split('-')
+        return parts
+
+    def to_url(self, value):
+        if isinstance(value, list):
+            return '-'.join(value)
+        return value

--- a/solution/backend/regulations/templates/regulations/partials/expanded_toc/appendix.html
+++ b/solution/backend/regulations/templates/regulations/partials/expanded_toc/appendix.html
@@ -5,7 +5,11 @@
         <div class="toc-section-name">[Reserved]</div>
     </span>
     {% else %}
+    {% if subpart %}
     <a class="menu-section" href="{% url 'reader_view' title part subpart version %}#{{identifier|join:'-' }}" data-section-id="{{identifier|join:'-' }}" id="nav-{{identifier|join:'-'}}">
+    {% else %}
+    <a class="menu-section" href="{% url 'reader_view' title part version %}#{{identifier|join:'-' }}" data-section-id="{{identifier|join:'-' }}" id="nav-{{identifier|join:'-'}}">
+    {% endif %}
         <div class="flexbox">
             <span class="toc-section-number">{{ label_level }}</span>
             <span class="toc-section-name">{{label_description|safe}}</span>

--- a/solution/backend/regulations/templates/regulations/partials/expanded_toc/appendix.html
+++ b/solution/backend/regulations/templates/regulations/partials/expanded_toc/appendix.html
@@ -8,7 +8,7 @@
     {% if subpart %}
     <a class="menu-section" href="{% url 'reader_view' title part subpart version %}#{{identifier|join:'-' }}" data-section-id="{{identifier|join:'-' }}" id="nav-{{identifier|join:'-'}}">
     {% else %}
-    <a class="menu-section" href="{% url 'reader_view' title part version %}#{{identifier|join:'-' }}" data-section-id="{{identifier|join:'-' }}" id="nav-{{identifier|join:'-'}}">
+    <a class="menu-section" href="{% url 'reader_view' title part identifier|join:'-' version %}" data-section-id="{{identifier|join:'-' }}" id="nav-{{identifier|join:'-'}}">
     {% endif %}
         <div class="flexbox">
             <span class="toc-section-number">{{ label_level }}</span>

--- a/solution/backend/regulations/templates/regulations/partials/node_types/APPENDIX.html
+++ b/solution/backend/regulations/templates/regulations/partials/node_types/APPENDIX.html
@@ -1,5 +1,5 @@
 {% comment %}
-    Used once per section. Contained by subparts at the top level.
+    Used once per section. Can be contained by subparts or by parts.
 {% endcomment %}
 {% load string_formatters %}
 

--- a/solution/backend/regulations/templates/regulations/partials/sidebar_left/subpart.html
+++ b/solution/backend/regulations/templates/regulations/partials/sidebar_left/subpart.html
@@ -6,6 +6,8 @@
         {% for item in toc.children %}
             {% if item.type == "section" %}
                 {% include "regulations/partials/sidebar_left/subpart/orphan_section.html" with extra_class="orphan" %}
+            {% elif item.type == "appendix" %}
+                {% include "regulations/partials/sidebar_left/subpart/orphan_appendix.html" with extra_class="orphan" %}
             {% elif item.type == "subpart" %}
                 {% if subpart and item.identifier.0 == subpart %}
                     {% include "regulations/partials/sidebar_left/subpart/subpart.html" with collapse_state="expanded" %}

--- a/solution/backend/regulations/templates/regulations/partials/sidebar_left/subpart/appendix.html
+++ b/solution/backend/regulations/templates/regulations/partials/sidebar_left/subpart/appendix.html
@@ -1,13 +1,22 @@
 <li class="{{ extra_class }}">
     {% if item.reserved %}
-    <span class="menu-section">
-        <div class="toc-section-number">{{ item.label_level }}</div>
-        <div class="toc-section-name">[Reserved]</div>
-    </span>
+        <span class="menu-section">
+            <div class="toc-section-number">{{ item.label_level }}</div>
+            <div class="toc-section-name">[Reserved]</div>
+        </span>
     {% else %}
-    <a class="menu-section" href="{% url 'reader_view' title reg_part item.identifier|join:'-' version %}" data-section-id="{{item.identifier|join:'-' }}" id="nav-{{item.identifier|join:'-'}}">
-        <div class="toc-section-number">{{ item.label_level }}</div>
-        <div class="toc-section-name">{{item.label_description|safe}}</div>
-    </a>
+        {% if item.parent_type == 'subpart' %}
+            <!-- For appendices within subparts, use anchor links -->
+            <a class="menu-section" href="{% url 'reader_view' title reg_part subpart version %}#{{item.identifier|join:'-' }}" data-section-id="{{item.identifier|join:'-' }}" id="nav-{{item.identifier|join:'-'}}">
+                <div class="toc-section-number">{{ item.label_level }}</div>
+                <div class="toc-section-name">{{item.label_description|safe}}</div>
+            </a>
+        {% else %}
+            <!-- For appendices directly under parts, use dedicated pages -->
+            <a class="menu-section" href="{% url 'reader_view' title reg_part item.identifier|join:'-' version %}" data-section-id="{{item.identifier|join:'-' }}" id="nav-{{item.identifier|join:'-'}}">
+                <div class="toc-section-number">{{ item.label_level }}</div>
+                <div class="toc-section-name">{{item.label_description|safe}}</div>
+            </a>
+        {% endif %}
     {% endif %}
 </li>

--- a/solution/backend/regulations/templates/regulations/partials/sidebar_left/subpart/appendix.html
+++ b/solution/backend/regulations/templates/regulations/partials/sidebar_left/subpart/appendix.html
@@ -5,7 +5,7 @@
         <div class="toc-section-name">[Reserved]</div>
     </span>
     {% else %}
-    <a class="menu-section" href="{% url 'reader_view' title reg_part subpart version %}#{{item.identifier|join:'-' }}" data-section-id="{{item.identifier|join:'-' }}" id="nav-{{item.identifier|join:'-'}}">
+    <a class="menu-section" href="{% url 'reader_view' title reg_part item.identifier|join:'-' version %}" data-section-id="{{item.identifier|join:'-' }}" id="nav-{{item.identifier|join:'-'}}">
         <div class="toc-section-number">{{ item.label_level }}</div>
         <div class="toc-section-name">{{item.label_description|safe}}</div>
     </a>

--- a/solution/backend/regulations/templates/regulations/partials/sidebar_left/subpart/orphan_appendix.html
+++ b/solution/backend/regulations/templates/regulations/partials/sidebar_left/subpart/orphan_appendix.html
@@ -1,4 +1,4 @@
-<li class="{{ extra_class }}">
+<li class="{{ extra_class }} {% if appendix and item.identifier|join:'-' == appendix_data.identifier|join:'-' %}active{% endif %}">
     {% if item.reserved %}
     <span class="menu-section">
         <div class="toc-section-number">{{ item.label_level }}</div>

--- a/solution/backend/regulations/templates/regulations/partials/sidebar_left/subpart/orphan_appendix.html
+++ b/solution/backend/regulations/templates/regulations/partials/sidebar_left/subpart/orphan_appendix.html
@@ -5,7 +5,7 @@
         <div class="toc-section-name">[Reserved]</div>
     </span>
     {% else %}
-    <a class="menu-section" href="{% url 'reader_view' title reg_part version %}#{{item.identifier|join:'-' }}" data-section-id="{{item.identifier|join:'-' }}" id="nav-{{item.identifier|join:'-'}}">
+    <a class="menu-section" href="{% url 'reader_view' title reg_part item.identifier|join:'-' version %}" data-section-id="{{item.identifier|join:'-' }}" id="nav-{{item.identifier|join:'-'}}">
         <div class="toc-section-number">{{ item.label_level }}</div>
         <div class="toc-section-name">{{item.label_description|safe}}</div>
     </a>

--- a/solution/backend/regulations/templates/regulations/partials/sidebar_left/subpart/orphan_appendix.html
+++ b/solution/backend/regulations/templates/regulations/partials/sidebar_left/subpart/orphan_appendix.html
@@ -1,0 +1,13 @@
+<li class="{{ extra_class }}">
+    {% if item.reserved %}
+    <span class="menu-section">
+        <div class="toc-section-number">{{ item.label_level }}</div>
+        <div class="toc-section-name">[Reserved]</div>
+    </span>
+    {% else %}
+    <a class="menu-section" href="{% url 'reader_view' title reg_part version %}#{{item.identifier|join:'-' }}" data-section-id="{{item.identifier|join:'-' }}" id="nav-{{item.identifier|join:'-'}}">
+        <div class="toc-section-number">{{ item.label_level }}</div>
+        <div class="toc-section-name">{{item.label_description|safe}}</div>
+    </a>
+    {% endif %}
+</li>

--- a/solution/backend/regulations/templates/regulations/partials/sidebar_right.html
+++ b/solution/backend/regulations/templates/regulations/partials/sidebar_right.html
@@ -1,7 +1,7 @@
 {% load string_formatters %}
 
 <section id="right-sidebar" data-cache-key="sidebar" data-cache-value="{{label_id}}">
-    {% if node_list %}
+    {% if node_list and not appendix %}
         <supplemental-content
             api-url="{{ API_BASE }}"
             title="{{ title }}"

--- a/solution/backend/regulations/templates/regulations/partials/view-and-compare.html
+++ b/solution/backend/regulations/templates/regulations/partials/view-and-compare.html
@@ -11,29 +11,37 @@
             >
                 <option value="" disabled>Select Date</option>
                 {% for version in versions %}
-                    {% if citation.1 %}
+                    {% if appendix %}
+                        <option data-url="{% url 'reader_view' title citation.0 appendix_data.identifier|join:'-' version.date %}">{{version.date|version_date}}</option>
+                    {% elif citation.1 %}
                         <option data-url="{% url 'reader_view' title citation.0 citation.1 version.date %}">{{version.date|version_date}}</option>
                     {% else %}
                         <option data-url="{% url 'reader_view' title citation.0 version.date %}">{{version.date|version_date}}</option>
                     {% endif %}
-
                 {% endfor %}
             </select>
         </span>
-        {% if citation.1 %}
-        <a
-            id="close-link"
-            class="close-button"
-            href="{% url 'reader_view' title citation.0 citation.1 versions.0.date  %}"
-            aria-label="close view past versions"
-        >
+        {% if appendix %}
+            <a
+                id="close-link"
+                class="close-button"
+                href="{% url 'reader_view' title citation.0 appendix_data.identifier|join:'-' versions.0.date %}"
+                aria-label="close view past versions"
+            >
+        {% elif citation.1 %}
+            <a
+                id="close-link"
+                class="close-button"
+                href="{% url 'reader_view' title citation.0 citation.1 versions.0.date %}"
+                aria-label="close view past versions"
+            >
         {% else %}
-        <a
-            id="close-link"
-            class="close-button"
-            href="{% url 'reader_view' title citation.0 versions.0.date  %}"
-            aria-label="close view past versions"
-        >
+            <a
+                id="close-link"
+                class="close-button"
+                href="{% url 'reader_view' title citation.0 versions.0.date %}"
+                aria-label="close view past versions"
+            >
         {% endif %}
             <svg width="17" height="17" viewBox="0 0 17 17" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <title>Close</title>

--- a/solution/backend/regulations/templates/regulations/reader.html
+++ b/solution/backend/regulations/templates/regulations/reader.html
@@ -27,7 +27,7 @@
 
             <main class="reg-text match-middle" id="main-content">
                 {% ecfr_part_url_formatter title reg_part as ecfr_part_url %}
-                <p class="up-to-date{{ subpart|yesno:" subpart," }}">
+                <p class="up-to-date{{ subpart|yesno:" subpart," }}{{ appendix|yesno:" appendix," }}">
                 <a href="{{ecfr_part_url}}" target="_blank" rel="noopener noreferrer" class="external">
                     {{ toc.label_level }} up to date from eCFR
                 </a> as of {{ parser_last_success|parser_success_date_formatter }}{% if is_latest_version and has_meaningful_latest_version_date %}<span class="latest-version">; last amended </span>{{ formatted_latest_version }}{% endif %}.

--- a/solution/backend/regulations/urls.py
+++ b/solution/backend/regulations/urls.py
@@ -13,6 +13,7 @@ from regulations.views.reader import (
     PartReaderView,
     SectionReaderView,
     SubpartReaderView,
+    AppendixReaderView,
 )
 from regulations.views.redirect import RegulationRedirectView
 from regulations.views.regulation_landing import RegulationLandingView
@@ -25,6 +26,7 @@ from regulations.views.subjects import SubjectsView
 register_converter(converters.NumericConverter, 'numeric')
 register_converter(converters.SubpartConverter, 'subpart')
 register_converter(converters.VersionConverter, 'version')
+register_converter(converters.AppendixConverter, 'appendix')
 
 urlpatterns = [
     path('', HomepageView.as_view(), name='homepage'),
@@ -40,6 +42,12 @@ urlpatterns = [
          name="reader_view"),
     path('<numeric:title>/<numeric:part>/Subpart-<subpart:subpart>/',
          SubpartReaderView.as_view(),
+         name="reader_view"),
+    path('<numeric:title>/<numeric:part>/<appendix:appendix>/',
+         AppendixReaderView.as_view(),
+         name="reader_view"),
+    path('<numeric:title>/<numeric:part>/<appendix:appendix>/<version:version>/',
+         AppendixReaderView.as_view(),
          name="reader_view"),
     path('<numeric:title>/<numeric:part>/<version:version>/', PartReaderView.as_view(), name='reader_view'),
     path('goto/', GoToRedirectView.as_view(), name='goto'),
@@ -60,5 +68,4 @@ urlpatterns = [
         })),
     ])),
     path('logout/', auth_views.LogoutView.as_view(), name='logout'),
-
 ]

--- a/solution/backend/regulations/views/reader.py
+++ b/solution/backend/regulations/views/reader.py
@@ -249,7 +249,8 @@ class AppendixReaderView(ReaderView):
         appendix_index = -1
 
         for i, child in enumerate(toc['children']):
-            if 'type' in child and child['type'] == 'appendix' and 'identifier' in child:
+            if ('type' in child and child['type'] == 'appendix' and
+                    'identifier' in child):
                 # Compare the full identifier to find the exact appendix
                 # Need to make a case-insensitive and format-insensitive comparison
 
@@ -262,39 +263,49 @@ class AppendixReaderView(ReaderView):
                 # with ["APPENDIX", "VIII", "TO", "PART", "75"]
 
                 # Find the appendix number index (usually index 1 if present)
-                appendix_num_index = 1 if len(url_identifier) > 1 and url_identifier[1] not in ["TO", "PART"] else None
+                appendix_num_index = (1 if len(url_identifier) > 1 and
+                                     url_identifier[1] not in ["TO", "PART"] else None)
 
                 if appendix_num_index:
                     # Compare appendix number and part number
                     url_appendix_num = url_identifier[appendix_num_index]
-                    child_appendix_num = child_identifier[appendix_num_index] if len(child_identifier) > appendix_num_index else None
+                    child_appendix_num = (child_identifier[appendix_num_index]
+                                         if len(child_identifier) > appendix_num_index else None)
 
                     # Get part numbers
-                    url_part_index = url_identifier.index("PART") + 1 if "PART" in url_identifier else None
-                    child_part_index = child_identifier.index("PART") + 1 if "PART" in child_identifier else None
+                    url_part_index = (url_identifier.index("PART") + 1
+                                     if "PART" in url_identifier else None)
+                    child_part_index = (child_identifier.index("PART") + 1
+                                       if "PART" in child_identifier else None)
 
-                    url_part_num = url_identifier[url_part_index] if url_part_index and url_part_index < len(url_identifier) else None
-                    child_part_num = child_identifier[child_part_index] if child_part_index and child_part_index < len(child_identifier) else None
+                    url_part_num = (url_identifier[url_part_index]
+                                   if url_part_index and url_part_index < len(url_identifier) else None)
+                    child_part_num = (child_identifier[child_part_index]
+                                     if child_part_index and child_part_index < len(child_identifier) else None)
 
                     # Match both appendix number and part number
                     if (url_appendix_num == child_appendix_num and
-                        url_part_num == child_part_num):
+                            url_part_num == child_part_num):
                         appendix_index = i
                         context['appendix_data'] = child
                         break
                 else:
                     # Handle case with no appendix number (just "Appendix to Part X")
                     # Compare just the part numbers
-                    url_part_index = url_identifier.index("PART") + 1 if "PART" in url_identifier else None
-                    child_part_index = child_identifier.index("PART") + 1 if "PART" in child_identifier else None
+                    url_part_index = (url_identifier.index("PART") + 1
+                                     if "PART" in url_identifier else None)
+                    child_part_index = (child_identifier.index("PART") + 1
+                                       if "PART" in child_identifier else None)
 
-                    url_part_num = url_identifier[url_part_index] if url_part_index and url_part_index < len(url_identifier) else None
-                    child_part_num = child_identifier[child_part_index] if child_part_index and child_part_index < len(child_identifier) else None
+                    url_part_num = (url_identifier[url_part_index]
+                                   if url_part_index and url_part_index < len(url_identifier) else None)
+                    child_part_num = (child_identifier[child_part_index]
+                                     if child_part_index and child_part_index < len(child_identifier) else None)
 
                     # If neither has an appendix number and part numbers match
                     if (("TO" in url_identifier and "TO" in child_identifier) and
-                        url_part_num == child_part_num and
-                        url_identifier[0] == child_identifier[0]):  # Both start with "APPENDIX"
+                            url_part_num == child_part_num and
+                            url_identifier[0] == child_identifier[0]):  # Both start with "APPENDIX"
                         appendix_index = i
                         context['appendix_data'] = child
                         break

--- a/solution/backend/regulations/views/reader.py
+++ b/solution/backend/regulations/views/reader.py
@@ -250,7 +250,7 @@ class AppendixReaderView(ReaderView):
 
         for i, child in enumerate(toc['children']):
             if ('type' in child and child['type'] == 'appendix' and
-                    'identifier' in child):
+                'identifier' in child):
                 # Compare the full identifier to find the exact appendix
                 # Need to make a case-insensitive and format-insensitive comparison
 
@@ -264,24 +264,24 @@ class AppendixReaderView(ReaderView):
 
                 # Find the appendix number index (usually index 1 if present)
                 appendix_num_index = (1 if len(url_identifier) > 1 and
-                                     url_identifier[1] not in ["TO", "PART"] else None)
+                                      url_identifier[1] not in ["TO", "PART"] else None)
 
                 if appendix_num_index:
                     # Compare appendix number and part number
                     url_appendix_num = url_identifier[appendix_num_index]
                     child_appendix_num = (child_identifier[appendix_num_index]
-                                         if len(child_identifier) > appendix_num_index else None)
+                                          if len(child_identifier) > appendix_num_index else None)
 
                     # Get part numbers
                     url_part_index = (url_identifier.index("PART") + 1
-                                     if "PART" in url_identifier else None)
+                                      if "PART" in url_identifier else None)
                     child_part_index = (child_identifier.index("PART") + 1
-                                       if "PART" in child_identifier else None)
+                                        if "PART" in child_identifier else None)
 
                     url_part_num = (url_identifier[url_part_index]
-                                   if url_part_index and url_part_index < len(url_identifier) else None)
+                                    if url_part_index and url_part_index < len(url_identifier) else None)
                     child_part_num = (child_identifier[child_part_index]
-                                     if child_part_index and child_part_index < len(child_identifier) else None)
+                                      if child_part_index and child_part_index < len(child_identifier) else None)
 
                     # Match both appendix number and part number
                     if (url_appendix_num == child_appendix_num and
@@ -293,14 +293,14 @@ class AppendixReaderView(ReaderView):
                     # Handle case with no appendix number (just "Appendix to Part X")
                     # Compare just the part numbers
                     url_part_index = (url_identifier.index("PART") + 1
-                                     if "PART" in url_identifier else None)
+                                      if "PART" in url_identifier else None)
                     child_part_index = (child_identifier.index("PART") + 1
-                                       if "PART" in child_identifier else None)
+                                        if "PART" in child_identifier else None)
 
                     url_part_num = (url_identifier[url_part_index]
-                                   if url_part_index and url_part_index < len(url_identifier) else None)
+                                    if url_part_index and url_part_index < len(url_identifier) else None)
                     child_part_num = (child_identifier[child_part_index]
-                                     if child_part_index and child_part_index < len(child_identifier) else None)
+                                      if child_part_index and child_part_index < len(child_identifier) else None)
 
                     # If neither has an appendix number and part numbers match
                     if (("TO" in url_identifier and "TO" in child_identifier) and

--- a/solution/backend/regulations/views/reader.py
+++ b/solution/backend/regulations/views/reader.py
@@ -235,3 +235,73 @@ class SectionReaderView(View):
         redirect_url = url + "?highlight=" + query_string.replace('%', '%25') if query_string else url
 
         return HttpResponseRedirect(redirect_url)
+
+
+class AppendixReaderView(ReaderView):
+    def get_view_type(self):
+        return "appendix"
+
+    def get_content(self, context, document, toc):
+        # Get the appendix identifier from the URL
+        appendix_path = context.get('appendix')
+
+        # Find the appendix in the document structure
+        appendix_index = -1
+
+        for i, child in enumerate(toc['children']):
+            if 'type' in child and child['type'] == 'appendix' and 'identifier' in child:
+                # Compare the full identifier to find the exact appendix
+                # Need to make a case-insensitive and format-insensitive comparison
+
+                # First, standardize both identifiers for comparison
+                url_identifier = [part.upper() for part in appendix_path]
+                child_identifier = [part.upper() for part in child['identifier']]
+
+                # Check if the important parts match (Appendix number, part number)
+                # For example, match ["APPENDIX", "VIII", "TO", "PART", "75"]
+                # with ["APPENDIX", "VIII", "TO", "PART", "75"]
+
+                # Find the appendix number index (usually index 1 if present)
+                appendix_num_index = 1 if len(url_identifier) > 1 and url_identifier[1] not in ["TO", "PART"] else None
+
+                if appendix_num_index:
+                    # Compare appendix number and part number
+                    url_appendix_num = url_identifier[appendix_num_index]
+                    child_appendix_num = child_identifier[appendix_num_index] if len(child_identifier) > appendix_num_index else None
+
+                    # Get part numbers
+                    url_part_index = url_identifier.index("PART") + 1 if "PART" in url_identifier else None
+                    child_part_index = child_identifier.index("PART") + 1 if "PART" in child_identifier else None
+
+                    url_part_num = url_identifier[url_part_index] if url_part_index and url_part_index < len(url_identifier) else None
+                    child_part_num = child_identifier[child_part_index] if child_part_index and child_part_index < len(child_identifier) else None
+
+                    # Match both appendix number and part number
+                    if (url_appendix_num == child_appendix_num and
+                        url_part_num == child_part_num):
+                        appendix_index = i
+                        context['appendix_data'] = child
+                        break
+                else:
+                    # Handle case with no appendix number (just "Appendix to Part X")
+                    # Compare just the part numbers
+                    url_part_index = url_identifier.index("PART") + 1 if "PART" in url_identifier else None
+                    child_part_index = child_identifier.index("PART") + 1 if "PART" in child_identifier else None
+
+                    url_part_num = url_identifier[url_part_index] if url_part_index and url_part_index < len(url_identifier) else None
+                    child_part_num = child_identifier[child_part_index] if child_part_index and child_part_index < len(child_identifier) else None
+
+                    # If neither has an appendix number and part numbers match
+                    if (("TO" in url_identifier and "TO" in child_identifier) and
+                        url_part_num == child_part_num and
+                        url_identifier[0] == child_identifier[0]):  # Both start with "APPENDIX"
+                        appendix_index = i
+                        context['appendix_data'] = child
+                        break
+
+        if appendix_index == -1:
+            raise Http404
+
+        content = document['children'][appendix_index]
+        context['appendix'] = True  # Flag that we're viewing an appendix
+        return content

--- a/solution/parser/lib/parsexml/parsexml.go
+++ b/solution/parser/lib/parsexml/parsexml.go
@@ -359,6 +359,18 @@ func (c *AppendixChildren) UnmarshalXML(d *xml.Decoder, start xml.StartElement) 
 			return err
 		}
 		*c = append(*c, child)
+	case "HD2":
+		child := &Heading{Type: "Heading2"}
+		if err := d.DecodeElement(child, &start); err != nil {
+			return err
+		}
+		*c = append(*c, child)
+	case "HD3":
+		child := &Heading{Type: "Heading3"}
+		if err := d.DecodeElement(child, &start); err != nil {
+			return err
+		}
+		*c = append(*c, child)
 	case "DIV":
 		child := &Division{Type: "Division"}
 		if err := d.DecodeElement(child, &start); err != nil {

--- a/solution/parser/lib/parsexml/parsexml.go
+++ b/solution/parser/lib/parsexml/parsexml.go
@@ -82,6 +82,12 @@ func (c *PartChildren) UnmarshalXML(d *xml.Decoder, start xml.StartElement) erro
 			return err
 		}
 		*c = append(*c, child)
+	case "DIV9":
+		child := &Appendix{}
+		if err := d.DecodeElement(child, &start); err != nil {
+			return err
+		}
+		*c = append(*c, child)
 	default:
 		logParseError(fmt.Sprintf("Unknown XML type in part %+v", start))
 		d.Skip()
@@ -176,7 +182,7 @@ func (sg *SubjectGroup) PostProcess() {
 // SubjectGroupChildren is an array of interface
 type SubjectGroupChildren []interface{}
 
-// UnmarshalXML defines how to unmarshall a SUbjectGroupChildren from XMl
+// UnmarshalXML defines how to unmarshall a SubjectGroupChildren from XMl
 func (c *SubjectGroupChildren) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	switch start.Name.Local {
 	case "DIV8":
@@ -327,7 +333,7 @@ func (sl *SectionCitation) UnmarshalText(data []byte) error {
 	return nil
 }
 
-// Appendix is the struct fro an appendix to the regulation
+// Appendix is the struct for an appendix to the regulation
 type Appendix struct {
 	Type     string           `xml:"TYPE,attr" json:"node_type"`
 	Citation AppendixCitation `xml:"N,attr" json:"label"`
@@ -349,6 +355,24 @@ func (c *AppendixChildren) UnmarshalXML(d *xml.Decoder, start xml.StartElement) 
 		*c = append(*c, child)
 	case "HD1":
 		child := &Heading{Type: "Heading"}
+		if err := d.DecodeElement(child, &start); err != nil {
+			return err
+		}
+		*c = append(*c, child)
+	case "DIV":
+		child := &Division{Type: "Division"}
+		if err := d.DecodeElement(child, &start); err != nil {
+			return err
+		}
+		*c = append(*c, child)
+	case "TABLE":
+		child := &Division{Type: "Table", Content: "<table>" + start.Name.Local + "</table>"}
+		if err := d.DecodeElement(child, &start); err != nil {
+			return err
+		}
+		*c = append(*c, child)
+	case "FTNT":
+		child := &FootNote{Type: "FootNote"}
 		if err := d.DecodeElement(child, &start); err != nil {
 			return err
 		}

--- a/solution/parser/lib/parsexml/parsexml.go
+++ b/solution/parser/lib/parsexml/parsexml.go
@@ -353,6 +353,16 @@ func (c *AppendixChildren) UnmarshalXML(d *xml.Decoder, start xml.StartElement) 
 			return err
 		}
 		*c = append(*c, child)
+	case "FP":
+		fallthrough
+	case "FP-1":
+		fallthrough
+	case "FP-2":
+		child := &FlushParagraph{Type: "FlushParagraph"}
+		if err := d.DecodeElement(child, &start); err != nil {
+			return err
+		}
+		*c = append(*c, child)
 	case "HD1":
 		child := &Heading{Type: "Heading"}
 		if err := d.DecodeElement(child, &start); err != nil {
@@ -385,6 +395,12 @@ func (c *AppendixChildren) UnmarshalXML(d *xml.Decoder, start xml.StartElement) 
 		*c = append(*c, child)
 	case "FTNT":
 		child := &FootNote{Type: "FootNote"}
+		if err := d.DecodeElement(child, &start); err != nil {
+			return err
+		}
+		*c = append(*c, child)
+	case "CITA":
+		child := &Citation{Type: "Citation"}
 		if err := d.DecodeElement(child, &start); err != nil {
 			return err
 		}

--- a/solution/ui/regulations/eregs-vite/src/components/JumpTo.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/JumpTo.vue
@@ -152,10 +152,7 @@ export default {
     methods: {
         async getParts(title) {
             const partsList = await fetchParts({ title, apiUrl: this.apiUrl });
-            // temporarily filter part 75. See EREGCSC-1397
-            this.filteredParts = partsList
-                .map((part) => part.name)
-                .filter((part) => part !== "75");
+            this.filteredParts = partsList.map((part) => part.name);
         },
         getLink() {
             let link = `${this.homeUrl}goto/?title=${this.selectedTitle}&part=${this.selectedPart}`;


### PR DESCRIPTION
Resolves #EREGCSC-1397 (mostly). Should meet most of the acceptance criteria for EREGCSC-1397 except:

- Does not enable search indexing for part-level appendixes. Probably makes sense to handle in a follow-up story.
- Subheadings within appendixes don't have nice styling. That's ok. We can improve it later if we want to.
- Does not include tests yet.

**Description-**

Goal is to enable parts like 5 CFR 720 and 45 CFR 75 that have part-level appendixes, while preserving our existing functionality for subpart-level appendixes, such as for 42 CFR 441 Subpart F.

**This pull request changes...**

- Remove old special case that hid 45 CFR 75 in jump-to.
- Parse part-level appendixes, including a variety of special text that can come along with them, such as tables, headings, and footnotes.
- Show part-level appendixes on regulation part ToC homepages.
- Show part-level appendixes in left navigation sidebars for regulations.
- Part-level appendixes are their own pages with nice URLs, with no supplemental content in the right sidebar.

**Steps to manually verify this change...**

1. Configure parser to import 45 CFR 75 text
2. After import, go to part homepage and click on appendixes
3. Click on appendixes in left sidebars on those regulations
4. Compare the display of appendixes to the eCFR pages for those appendixes; check that no text is missing or broken
5. Go to 42 CFR 441 homepage and click the Subpart F appendix
6. Click the Subpart F appendix in the 42 CFR 441 left nav
7. Make sure you can still read the Subpart F appendix
8. Jump to a 45 CFR 75 section