### PR TITLE
Redirect www to main policyconnector.digital site

### DIFF
--- a/solution/backend/cmcs_regulations/settings/base.py
+++ b/solution/backend/cmcs_regulations/settings/base.py
@@ -28,7 +28,8 @@ FORCE_SCRIPT_NAME = os.environ.get("FORCE_SCRIPT_NAME")
 ALLOWED_HOSTS = [os.environ.get('ALLOWED_HOST'),
                  'localhost',
                  'host.docker.internal',
-                 'policyconnector.digital']
+                 'policyconnector.digital',
+                 'www.policyconnector.digital']
 
 # Application definition
 
@@ -59,6 +60,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    'regulations.middleware.WwwRedirectMiddleware',
     'django.middleware.security.SecurityMiddleware',
     "debug_toolbar.middleware.DebugToolbarMiddleware",
     'django.contrib.sessions.middleware.SessionMiddleware',

--- a/solution/backend/regulations/middleware.py
+++ b/solution/backend/regulations/middleware.py
@@ -1,9 +1,27 @@
 import json
 import traceback
 
-from django.http.response import HttpResponse
+from django.http.response import HttpResponse, HttpResponsePermanentRedirect
 
 from regulations.models import SiteConfiguration
+
+
+class WwwRedirectMiddleware:
+    """
+    Middleware to redirect www.policyconnector.digital to policyconnector.digital
+    """
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        host = request.get_host()
+        
+        # If request is specifically for www.policyconnector.digital, redirect to root domain
+        if host == 'www.policyconnector.digital':
+            new_url = f"{request.scheme}://policyconnector.digital{request.get_full_path()}"
+            return HttpResponsePermanentRedirect(new_url)
+        
+        return self.get_response(request)
 
 
 class ProcessResponse:


### PR DESCRIPTION
Adds a redirect middleware to redirect all www middleware to the main site.